### PR TITLE
Trigger Nushell fallback to stdio on attempt to run local socket mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This is probably only useful for people writing plugins in languages other than 
 
 Requires the new plugin API of Nu >= 0.93
 
-The new `local-socket` feature is not currently supported, so plugins must be built with `nu-plugin` dependency with `default-features = false`.
-
 ## Usage
 
 Add the plugin using the tracer as a shell interpreter, using the full paths of the plugin tracer and the actual plugin.


### PR DESCRIPTION
If Nushell fails to launch a plugin with local socket mode, even if the plugin advertises support for it, it automatically falls back to stdio mode. This is so that if for some reason you're doing something strange (like piping the data through something :wink:) or your operating system hates you, it still might work.

We can trigger this fallback by just silently exiting when we encounter the `--local-socket` arg. Nushell will treat this as something having gone wrong, and launch with stdio.

It might be nice to support local socket mode anyway, since there are some plugins that can't work without it, generally terminal interface plugins.

By the way, this runs great for me, with `msgpack` too and the new `from msgpack --objects` command on the nushell side I can read the output, which is awesome
